### PR TITLE
Feature: use tags in terragrunt git refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - Feb 1, 2022
+
+### Changed
+
+- fixed bugs in the example notifiers around kwargs processing.
+- moved to tag-based refs in terragrunt configurations to show a best practice using a stable artifact.
+
 ## [0.1.0] - Jan 31, 2022
 
 ### Added

--- a/demo/terragrunt/cloud-deploy-foundation/terragrunt.hcl
+++ b/demo/terragrunt/cloud-deploy-foundation/terragrunt.hcl
@@ -3,9 +3,8 @@ include {
 }
 
 terraform {
-  # TODO(bjb): switch to a tag ref
-  # source = "github.com/computeclub/gcp-cloud-deploy-notifiers//terraform/cloud-deploy-notification-infra?ref=main"
-  source = "${find_in_parent_folders("gcp-cloud-deploy-notifiers")}//terraform/cloud-deploy-notification-infra"
+  source = "github.com/computeclub/gcp-cloud-deploy-notifiers//terraform/cloud-deploy-notification-infra?ref=v0.1.0"
+  # source = "${find_in_parent_folders("gcp-cloud-deploy-notifiers")}//terraform/cloud-deploy-notification-infra"
 }
 
 locals {

--- a/demo/terragrunt/echo-fastapi/terragrunt.hcl
+++ b/demo/terragrunt/echo-fastapi/terragrunt.hcl
@@ -3,9 +3,8 @@ include {
 }
 
 terraform {
-  # TODO(bjb): switch to a tag ref
-  # source = "github.com/computeclub/gcp-cloud-deploy-notifiers//terraform/cloud-deploy-notifier?ref=main"
-  source = "${find_in_parent_folders("gcp-cloud-deploy-notifiers")}//terraform/cloud-deploy-notifier"
+  source = "github.com/computeclub/gcp-cloud-deploy-notifiers//terraform/cloud-deploy-notifier?ref=v0.1.0"
+  # source = "${find_in_parent_folders("gcp-cloud-deploy-notifiers")}//terraform/cloud-deploy-notifier"
   before_hook "before_hook" {
     commands = ["apply"]
     execute = [

--- a/demo/terragrunt/nginx-app-infra/terragrunt.hcl
+++ b/demo/terragrunt/nginx-app-infra/terragrunt.hcl
@@ -3,8 +3,6 @@ include {
 }
 
 terraform {
-  # TODO(bjb): switch to a tag ref
-  # source = "github.com/computeclub/gcp-cloud-deploy-notifiers//demo/nginx-app/terraform?ref=main"
   source = "${find_in_parent_folders("nginx-app")}//terraform"
   after_hook "after_hook" {
     commands = ["apply"]

--- a/demo/terragrunt/release-auto-promoter-notifier/terragrunt.hcl
+++ b/demo/terragrunt/release-auto-promoter-notifier/terragrunt.hcl
@@ -3,9 +3,8 @@ include {
 }
 
 terraform {
-  # TODO(bjb): switch to a tag ref
-  # source = "github.com/computeclub/gcp-cloud-deploy-notifiers//terraform/cloud-deploy-notifier?ref=main"
-  source = "${find_in_parent_folders("gcp-cloud-deploy-notifiers")}//terraform/cloud-deploy-notifier"
+  source = "github.com/computeclub/gcp-cloud-deploy-notifiers//terraform/cloud-deploy-notifier?ref=v0.1.0"
+  # source = "${find_in_parent_folders("gcp-cloud-deploy-notifiers")}//terraform/cloud-deploy-notifier"
   before_hook "before_hook" {
     commands = ["apply"]
     execute = [


### PR DESCRIPTION
## What is this change?

Migrates terragrunt git refs to tags.

## Why make this change?

This shows a common best practice.

## Links

None.